### PR TITLE
Supporting changes in armstrong.hatband URL routing. 

### DIFF
--- a/armstrong/core/arm_wells/templates/arm_wells/admin/well-node-inline.html
+++ b/armstrong/core/arm_wells/templates/arm_wells/admin/well-node-inline.html
@@ -25,6 +25,7 @@
         armstrong.widgets.generickey($, {
           facetURL: "{% url admin:generic_key_facets %}",
           queryLookupURL: "{% url admin:type_and_model_to_query %}",
+          baseLookupURL: "{% url admin:index %}",
           id: "id_{{ namespace }}-__prefix__-object_id",
           searchDone: function(app) {
             {{ namespace }}EmptyForm.trigger('createObject');


### PR DESCRIPTION
Hatband has a new base URL for performing the `/app_label/model/search/` lookups. This change follows ticket [#39](https://github.com/armstrong/armstrong/issues/39) regarding the hatband changes and the resolution in [PR #10](https://github.com/armstrong/armstrong.hatband/pull/10).
