### PR TITLE
Make sure that MergeQuerySet slices are always slicable

### DIFF
--- a/armstrong/core/arm_wells/querysets.py
+++ b/armstrong/core/arm_wells/querysets.py
@@ -81,7 +81,7 @@ class MergeQuerySet(object):
         if i >= qs_len:
             start = i - qs_len
             return self.queryset2[start:end]
-        return itertools.chain(self.queryset[i:], self.queryset2[0:end])
+        return list(itertools.chain(self.queryset[i:], self.queryset2[0:end]))
 
     def __getattr__(self, key):
         try:

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -244,3 +244,11 @@ class MergeQuerySetTestCase(TestCase):
         merge_qs = MergeQuerySet(self.qs_a.all(), self.qs_b.all())
         filtered = merge_qs.filter(id__lte=2)
         self.assertEqual(len(filtered), 2)
+
+    def test_is_slicable(self):
+        merge_qs = MergeQuerySet(self.qs_a.all(), self.qs_b.all())
+        sliced = merge_qs[0:self.number_in_a + 2]
+        try:
+            obj = sliced[1]
+        except TypeError:
+            self.fail("Threw a TypeError")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.3.1",
+    "version": "1.3.2.alpha.0",
     "description": "Provides the basic well objects",
     "install_requires": [
         "Django==1.3.1",


### PR DESCRIPTION
MergeQuerySet returns an itertools.chain object which is missing behaviors that are expected (like subscripting and slicing)
