### PR TITLE
MergeQueryset should use count instead of len to implement count

### DIFF
--- a/armstrong/core/arm_wells/querysets.py
+++ b/armstrong/core/arm_wells/querysets.py
@@ -70,7 +70,7 @@ class MergeQuerySet(object):
 
     @requires_prep
     def count(self):
-        return self.__len__()
+        return self.queryset.count() + self.queryset2.count()
 
     @requires_prep
     def __getslice__(self, i, j):
@@ -90,7 +90,7 @@ class MergeQuerySet(object):
             if key != 'queryset' and hasattr(QuerySet, key):
                 raise NotImplementedError()
             raise
-
+    
 
 class GenericForeignKeyQuerySet(object):
     def __init__(self, queryset, gfk='content_object'):

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -213,6 +213,12 @@ class MergeQuerySetTestCase(TestCase):
         self.assertEqual(merge_qs.count(),
                 len(merge_qs))
 
+    def test_count_does_not_call_length_on_queryset2(self):
+        merge_qs = MergeQuerySet(self.qs_a.all(), self.qs_b.all())
+        merge_qs.count()
+        with self.assertNumQueries(1):
+            len(merge_qs)
+
     def test_story_models_are_first(self):
         merge_qs = MergeQuerySet(self.qs_a.all(), self.qs_b.all())
         qs_a_copy = self.qs_a.all()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.3.2",
+    "version": "1.3.3alpha.0",
     "description": "Provides the basic well objects",
     "install_requires": [
         "Django==1.3.1",


### PR DESCRIPTION
Pagination of very large querysets can become pathologically bad if we do len instead of count, especially if (like we do at the Tribune) there is a subset of queryset that does complicated things on a per item basis
