### PR TITLE
 efficiency and tidying

### DIFF
--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -43,7 +43,7 @@ class Well(models.Model):
 
     @property
     def items(self):
-        node_qs = GenericForeignKeyQuerySet(self.nodes.all().select_related())
+        node_qs = GenericForeignKeyQuerySet(self.nodes.all())
         if self.queryset is None:
             return node_qs
         else:

--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -43,7 +43,7 @@ class Well(models.Model):
 
     @property
     def items(self):
-        node_qs = GenericForeignKeyQuerySet(self.nodes.all())
+        node_qs = GenericForeignKeyQuerySet(self.nodes.all().select_related())
         if self.queryset is None:
             return node_qs
         else:

--- a/armstrong/core/arm_wells/querysets.py
+++ b/armstrong/core/arm_wells/querysets.py
@@ -2,6 +2,7 @@ from functools import wraps
 from django.db.models.query import QuerySet
 import itertools
 
+
 def requires_prep(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -90,7 +91,7 @@ class MergeQuerySet(object):
             if key != 'queryset' and hasattr(QuerySet, key):
                 raise NotImplementedError()
             raise
-    
+
 
 class GenericForeignKeyQuerySet(object):
     def __init__(self, queryset, gfk='content_object'):

--- a/armstrong/core/arm_wells/tests/models.py
+++ b/armstrong/core/arm_wells/tests/models.py
@@ -1,23 +1,14 @@
 import datetime
-import fudge
-from fudge.inspector import arg
 import random
 
 from .arm_wells_support.models import Story
-from ._utils import add_n_random_stories_to_well
-from ._utils import generate_random_story
-from ._utils import generate_random_image
-from ._utils import generate_random_story_child
-from ._utils import generate_random_well
-from ._utils import generate_random_welltype
-from ._utils import TestCase
+from ._utils import TestCase, \
+                    add_n_random_stories_to_well, \
+                    generate_random_story, \
+                    generate_random_well, \
+                    generate_random_welltype
 
-from ..models import Node
-from ..models import Well
-from ..models import WellType
-from .. import models
-
-from django.template.context import Context
+from ..models import WellType, Well, Node
 
 
 class WellTestCase(TestCase):

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -24,7 +24,8 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
             self.extra_stories.append(generate_random_story())
 
     def test_raises_NotImplementedError_on_all_and_exclude(self):
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertRaises(NotImplementedError):
             gfk_qs.all()
         with self.assertRaises(NotImplementedError):
@@ -37,25 +38,29 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
                 'select_related', 'dup_select_related', 'annotate', 'order_by',
                 'distinct', 'extra', 'reverse', 'defer', 'only', 'using',
                 'ordered', ]
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         for func in funcs_to_test:
             with self.assertRaises(NotImplementedError):
                 getattr(gfk_qs, func)()
 
     def test_raises_AttributeError_on_unknown_attribute(self):
         """Necessary because of the NotImplementedError code"""
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertRaises(AttributeError):
             getattr(gfk_qs, "unknown_and_unknowable")
 
     def test_gathers_all_nodes_of_one_type_with_two_queries(self):
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertNumQueries(2):
             node_models = gfk_qs[0:self.number_in_well]
 
     def test_gathers_all_nodes_of_two_types_with_three_queries(self):
         add_n_random_images_to_well(self.number_in_well, self.well)
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertNumQueries(3):
             node_models = gfk_qs[0:self.number_in_well * 2]
 
@@ -103,7 +108,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         for i in range(num_nodes):
             OddNode.objects.create(baz=generate_random_story())
         gfk_qs = GenericForeignKeyQuerySet(
-                    OddNode.objects.all(),
+                    OddNode.objects.all().select_related(),
                     gfk='baz'
                 )
         with self.assertNumQueries(2):
@@ -116,7 +121,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
             OddNode.objects.create(baz=generate_random_story())
         with self.assertRaises(ValueError):
             gfk_qs = GenericForeignKeyQuerySet(
-                        OddNode.objects.all(),
+                        OddNode.objects.all().select_related(),
                         gfk='bad_field_name'
                     )
 

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -24,8 +24,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
             self.extra_stories.append(generate_random_story())
 
     def test_raises_NotImplementedError_on_all_and_exclude(self):
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                .select_related())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
         with self.assertRaises(NotImplementedError):
             gfk_qs.all()
         with self.assertRaises(NotImplementedError):
@@ -38,29 +37,25 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
                 'select_related', 'dup_select_related', 'annotate', 'order_by',
                 'distinct', 'extra', 'reverse', 'defer', 'only', 'using',
                 'ordered', ]
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                .select_related())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
         for func in funcs_to_test:
             with self.assertRaises(NotImplementedError):
                 getattr(gfk_qs, func)()
 
     def test_raises_AttributeError_on_unknown_attribute(self):
         """Necessary because of the NotImplementedError code"""
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                .select_related())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
         with self.assertRaises(AttributeError):
             getattr(gfk_qs, "unknown_and_unknowable")
 
     def test_gathers_all_nodes_of_one_type_with_two_queries(self):
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                .select_related())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
         with self.assertNumQueries(2):
             node_models = gfk_qs[0:self.number_in_well]
 
     def test_gathers_all_nodes_of_two_types_with_three_queries(self):
         add_n_random_images_to_well(self.number_in_well, self.well)
-        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                .select_related())
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all())
         with self.assertNumQueries(3):
             node_models = gfk_qs[0:self.number_in_well * 2]
 
@@ -108,7 +103,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         for i in range(num_nodes):
             OddNode.objects.create(baz=generate_random_story())
         gfk_qs = GenericForeignKeyQuerySet(
-                    OddNode.objects.all().select_related(),
+                    OddNode.objects.all(),
                     gfk='baz'
                 )
         with self.assertNumQueries(2):
@@ -121,7 +116,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
             OddNode.objects.create(baz=generate_random_story())
         with self.assertRaises(ValueError):
             gfk_qs = GenericForeignKeyQuerySet(
-                        OddNode.objects.all().select_related(),
+                        OddNode.objects.all(),
                         gfk='bad_field_name'
                     )
 

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -1,4 +1,3 @@
-from django.core.paginator import Paginator
 import random
 
 from .arm_wells_support.models import *
@@ -24,10 +23,12 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         for i in range(self.number_of_extra_stories):
             self.extra_stories.append(generate_random_story())
 
-    def test_raises_NotImplementedError_on_exclude(self):
+    def test_raises_NotImplementedError_on_all_and_exclude(self):
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertRaises(NotImplementedError):
-            gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                    .select_related())
+            gfk_qs.all()
+        with self.assertRaises(NotImplementedError):
             gfk_qs.exclude()
 
     def test_raises_NotImplementedError_on_misc_functions(self):
@@ -49,7 +50,6 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
                 .select_related())
         with self.assertRaises(AttributeError):
             getattr(gfk_qs, "unknown_and_unknowable")
-
 
     def test_gathers_all_nodes_of_one_type_with_two_queries(self):
         gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
@@ -162,7 +162,8 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
 
         queryset = well.items
         with self.assertRaises(FilterException):
-            self.assertEqual(3, len(queryset.filter(title__in=['foo','bar'])))
+            self.assertEqual(3, len(queryset.filter(title__in=['foo', 'bar'])))
+
 
 class MergeQuerySetTestCase(TestCase):
     def setUp(self):
@@ -178,9 +179,11 @@ class MergeQuerySetTestCase(TestCase):
             generate_random_image()
         self.qs_b = Image.objects.all()
 
-    def test_raises_NotImplementedError_on_exclude(self):
+    def test_raises_NotImplementedError_on_all_and_exclude(self):
+        merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
         with self.assertRaises(NotImplementedError):
-            merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
+            merge_qs.all()
+        with self.assertRaises(NotImplementedError):
             merge_qs.exclude()
 
     def test_raises_NotImplementedError_on_misc_functions(self):


### PR DESCRIPTION
Stop using `select_related()` on Well.items because we aren't concerned with subclasses of Nodes. Add a test for `GenericForeignKeyQuerySet.all()`. Removing unused imports. A touch of PEP8.
