### PR TITLE
Allow wells to not exist

### DIFF
--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -30,6 +30,10 @@ class SimpleWellViewTest(WellViewTestCase):
             "well_title": self.well.title,
         }
 
+    def test_get_well_returns_false_when_allow_empty_is_true(self):
+        view = self.view_class(well_title="unknown", allow_empty=True)
+        self.assertFalse(view.get_well())
+
     def test_raises_exception_without_template_name_param(self):
         kwargs = self.default_kwargs()
         del kwargs["template_name"]

--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -97,3 +97,16 @@ class QuerySetBackedWellViewTest(SimpleWellViewTest):
         queryset = view.get_queryset()
         expected = number_of_stories + self.number_in_well
         self.assertEqual(expected, len(queryset))
+
+    def test_get_queryset_returns_raw_queryset_if_there_is_an_empty_well(self):
+        kwargs = self.default_kwargs()
+        kwargs.update({
+            "allow_empty": True,
+            "well_title": "Unknown and Unkowable",
+        })
+        view = self.view_class(**kwargs)
+        stories = Story.objects.all()
+        queryset = view.get_queryset()
+        self.assertEqual(len(stories), len(queryset))
+        for story in stories:
+            self.assert_(story in queryset)

--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -102,7 +102,7 @@ class QuerySetBackedWellViewTest(SimpleWellViewTest):
         kwargs = self.default_kwargs()
         kwargs.update({
             "allow_empty": True,
-            "well_title": "Unknown and Unkowable",
+            "well_title": "Unknown and Unknowable",
         })
         view = self.view_class(**kwargs)
         stories = Story.objects.all()

--- a/armstrong/core/arm_wells/views.py
+++ b/armstrong/core/arm_wells/views.py
@@ -21,7 +21,7 @@ class SimpleWellView(TemplateView):
             return Well.objects.get_current(title=self.well_title)
         except Well.DoesNotExist:
             if self.allow_empty:
-                return False
+                return None
             raise
 
     def get_context_data(self, **kwargs):
@@ -33,7 +33,7 @@ class SimpleWellView(TemplateView):
 class QuerySetBackedWellView(SimpleWellView, MultipleObjectMixin):
     def get_queryset(self):
         well = self.get_well()
-        return (well.items if well is not False
+        return (well.items if well is not None
                 else super(QuerySetBackedWellView, self).get_queryset())
 
     def get_well(self):

--- a/armstrong/core/arm_wells/views.py
+++ b/armstrong/core/arm_wells/views.py
@@ -7,6 +7,7 @@ from .models import Well
 
 
 class SimpleWellView(TemplateView):
+    allow_empty = False
     well_title = None
 
     def __init__(self, *args, **kwargs):
@@ -16,7 +17,12 @@ class SimpleWellView(TemplateView):
                     _(u"Expects a `well_title` to be provided"))
 
     def get_well(self):
-        return Well.objects.get_current(title=self.well_title)
+        try:
+            return Well.objects.get_current(title=self.well_title)
+        except Well.DoesNotExist:
+            if self.allow_empty:
+                return False
+            raise
 
     def get_context_data(self, **kwargs):
         context = super(SimpleWellView, self).get_context_data(**kwargs)
@@ -30,6 +36,6 @@ class QuerySetBackedWellView(SimpleWellView, MultipleObjectMixin):
 
     def get_well(self):
         well = super(QuerySetBackedWellView, self).get_well()
-        well.merge_with(super(QuerySetBackedWellView, self).get_queryset())
+        if well:
+            well.merge_with(super(QuerySetBackedWellView, self).get_queryset())
         return well
-

--- a/armstrong/core/arm_wells/views.py
+++ b/armstrong/core/arm_wells/views.py
@@ -32,7 +32,9 @@ class SimpleWellView(TemplateView):
 
 class QuerySetBackedWellView(SimpleWellView, MultipleObjectMixin):
     def get_queryset(self):
-        return self.get_well().items
+        well = self.get_well()
+        return (well.items if well is not False
+                else super(QuerySetBackedWellView, self).get_queryset())
 
     def get_well(self):
         well = super(QuerySetBackedWellView, self).get_well()


### PR DESCRIPTION
Currently a well of some sort _has_ to exist for the various views to
work.  This makes that optional so you can turn that behavior off.
