### PR TITLE
Tidy tests

### DIFF
--- a/armstrong/core/arm_wells/tests/__init__.py
+++ b/armstrong/core/arm_wells/tests/__init__.py
@@ -3,4 +3,3 @@ from .models import *
 from .query import *
 from .querysets import *
 from .views import *
-from .arm_wells_support.tests import *

--- a/armstrong/core/arm_wells/tests/__init__.py
+++ b/armstrong/core/arm_wells/tests/__init__.py
@@ -3,3 +3,4 @@ from .models import *
 from .query import *
 from .querysets import *
 from .views import *
+from .arm_wells_support.tests import *

--- a/armstrong/core/arm_wells/tests/_utils.py
+++ b/armstrong/core/arm_wells/tests/_utils.py
@@ -1,12 +1,12 @@
 import random
 
-from django.test import TestCase as DjangoTestCase
-from django.test.client import RequestFactory
-
+from armstrong.dev.tests.utils.base import ArmstrongTestCase
 from .arm_wells_support.models import Story, StoryChild, Image
-from ..models import Node
-from ..models import Well
-from ..models import WellType
+from ..models import WellType, Well, Node
+
+
+class TestCase(ArmstrongTestCase):
+    pass
 
 
 def generate_random_image():
@@ -52,15 +52,3 @@ def generate_random_welltype():
     title = "Random Well %d" % r
     slug = "random-well-%d" % r
     return WellType.objects.create(title=title, slug=slug)
-
-
-class TestCase(DjangoTestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-
-    def assertInContext(self, var_name, other, template_or_context):
-        # TODO: support passing in a straight "context" (i.e., dict)
-        context = template_or_context.context_data
-        self.assertTrue(var_name in context,
-                msg="`%s` not in provided context" % var_name)
-        self.assertEqual(context[var_name], other)

--- a/armstrong/core/arm_wells/tests/arm_wells_support/models.py
+++ b/armstrong/core/arm_wells/tests/arm_wells_support/models.py
@@ -2,8 +2,10 @@ from django.db import models
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 
+
 class Content(models.Model):
     title = models.CharField(max_length=100)
+
     def __unicode__(self):
         return self.title
 

--- a/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
+++ b/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
@@ -1,7 +1,6 @@
 import random
 
-from django.test import TestCase
-
+from .._utils import TestCase
 from .models import Story
 
 

--- a/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
+++ b/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
@@ -1,6 +1,7 @@
 import random
 
-from .._utils import TestCase
+from django.test import TestCase
+
 from .models import Story
 
 

--- a/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
+++ b/armstrong/core/arm_wells/tests/arm_wells_support/tests.py
@@ -9,4 +9,4 @@ class StoryTestCase(TestCase):
         title = "Some Random Title %d" % random.randint(100, 200)
         story = Story(title=title)
 
-        self.assertEqual(title, str(story))
+        self.assertEqual(title, str(story), msg="sanity check")

--- a/armstrong/core/arm_wells/tests/managers.py
+++ b/armstrong/core/arm_wells/tests/managers.py
@@ -1,9 +1,7 @@
 import datetime
 
 from ._utils import TestCase
-
-from ..models import Well
-from ..models import WellType
+from ..models import WellType, Well
 
 
 class WellManagerTestCase(TestCase):

--- a/armstrong/core/arm_wells/tests/managers.py
+++ b/armstrong/core/arm_wells/tests/managers.py
@@ -1,6 +1,7 @@
 import datetime
 
 from ._utils import TestCase
+
 from ..models import WellType, Well
 
 

--- a/armstrong/core/arm_wells/tests/models.py
+++ b/armstrong/core/arm_wells/tests/models.py
@@ -110,7 +110,7 @@ class WellTestCase(TestCase):
         for node in well.nodes.all():
             self.assertEqual(node.content_object, well.items[i])
             i = i + 1
-        self.assertRaises(IndexError, lambda:well.items[i])
+        self.assertRaises(IndexError, lambda: well.items[i])
 
     def test_well_supports_indexing_with_merged_queryset(self):
         number_of_stories = random.randint(1, 5)
@@ -135,7 +135,7 @@ class WellTestCase(TestCase):
                 continue
             self.assertEqual(story, well.items[i])
             i = i + 1
-        self.assertRaises(IndexError, lambda:well.items[i])
+        self.assertRaises(IndexError, lambda: well.items[i])
 
 
 class NodeTestCase(TestCase):

--- a/armstrong/core/arm_wells/tests/query.py
+++ b/armstrong/core/arm_wells/tests/query.py
@@ -1,12 +1,11 @@
 from django.core.paginator import Paginator
 import random
 
-from .arm_wells_support.models import Image, Story
-from ._utils import (add_n_random_stories_to_well, add_n_random_images_to_well,
-        generate_random_image, generate_random_story, generate_random_well,
-        TestCase)
-
-from ..models import Node
+from .arm_wells_support.models import Story
+from ._utils import (TestCase,
+                     add_n_random_stories_to_well,
+                     generate_random_story,
+                     generate_random_well)
 
 
 class SimpleMergedNodesAndQuerySetTests(TestCase):
@@ -18,7 +17,7 @@ class SimpleMergedNodesAndQuerySetTests(TestCase):
         add_n_random_stories_to_well(2, well)
 
         queryset = well.merge_with(Story.objects.all())
-        sliced = [a for a in queryset[slice(1,3)]]
+        sliced = [a for a in queryset[slice(1, 3)]]
         self.assertEqual(2, len(sliced))
 
     def test_merges_correctly_when_sliced_across_the_well_content(self):

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -24,10 +24,12 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         for i in range(self.number_of_extra_stories):
             self.extra_stories.append(generate_random_story())
 
-    def test_raises_NotImplementedError_on_exclude(self):
+    def test_raises_NotImplementedError_on_all_and_exclude(self):
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertRaises(NotImplementedError):
-            gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
-                    .select_related())
+            gfk_qs.all()
+        with self.assertRaises(NotImplementedError):
             gfk_qs.exclude()
 
     def test_raises_NotImplementedError_on_misc_functions(self):
@@ -49,7 +51,6 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
                 .select_related())
         with self.assertRaises(AttributeError):
             getattr(gfk_qs, "unknown_and_unknowable")
-
 
     def test_gathers_all_nodes_of_one_type_with_two_queries(self):
         gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
@@ -178,9 +179,11 @@ class MergeQuerySetTestCase(TestCase):
             generate_random_image()
         self.qs_b = Image.objects.all()
 
-    def test_raises_NotImplementedError_on_exclude(self):
+    def test_raises_NotImplementedError_on_all_and_exclude(self):
+        merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
         with self.assertRaises(NotImplementedError):
-            merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
+            merge_qs.all()
+        with self.assertRaises(NotImplementedError):
             merge_qs.exclude()
 
     def test_raises_NotImplementedError_on_misc_functions(self):

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -26,11 +26,15 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         for i in range(self.number_of_extra_stories):
             self.extra_stories.append(generate_random_story())
 
-    def test_raises_NotImplementedError_on_all_and_exclude(self):
+    def test_raises_NotImplementedError_on_all(self):
         gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
                 .select_related())
         with self.assertRaises(NotImplementedError):
             gfk_qs.all()
+
+    def test_raises_NotImplementedError_on_exclude(self):
+        gfk_qs = GenericForeignKeyQuerySet(self.well.nodes.all()\
+                .select_related())
         with self.assertRaises(NotImplementedError):
             gfk_qs.exclude()
 
@@ -182,10 +186,13 @@ class MergeQuerySetTestCase(TestCase):
             generate_random_image()
         self.qs_b = Image.objects.all()
 
-    def test_raises_NotImplementedError_on_all_and_exclude(self):
+    def test_raises_NotImplementedError_on_all(self):
         merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
         with self.assertRaises(NotImplementedError):
             merge_qs.all()
+
+    def test_raises_NotImplementedError_on_exclude(self):
+        merge_qs = MergeQuerySet(self.qs_a, self.qs_b)
         with self.assertRaises(NotImplementedError):
             merge_qs.exclude()
 

--- a/armstrong/core/arm_wells/tests/querysets.py
+++ b/armstrong/core/arm_wells/tests/querysets.py
@@ -1,10 +1,12 @@
-from django.core.paginator import Paginator
 import random
 
 from .arm_wells_support.models import *
-from ._utils import (add_n_random_stories_to_well, add_n_random_images_to_well,
-        generate_random_image, generate_random_story, generate_random_well,
-        TestCase)
+from ._utils import (TestCase,
+                     add_n_random_stories_to_well,
+                     add_n_random_images_to_well,
+                     generate_random_image,
+                     generate_random_story,
+                     generate_random_well)
 
 from ..querysets import (GenericForeignKeyQuerySet, MergeQuerySet,
         FilterException)
@@ -105,7 +107,7 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
         self.assertEqual(2, len(queryset))
 
     def test_non_standard_node(self):
-        num_nodes = random.randint(3,5)
+        num_nodes = random.randint(3, 5)
         for i in range(num_nodes):
             OddNode.objects.create(baz=generate_random_story())
         gfk_qs = GenericForeignKeyQuerySet(
@@ -117,14 +119,14 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
                 self.assertEqual(obj.__class__, Story)
 
     def test_non_standard_node_failure(self):
-        num_nodes = random.randint(3,5)
+        num_nodes = random.randint(3, 5)
         for i in range(num_nodes):
             OddNode.objects.create(baz=generate_random_story())
         with self.assertRaises(ValueError):
-            gfk_qs = GenericForeignKeyQuerySet(
-                        OddNode.objects.all().select_related(),
-                        gfk='bad_field_name'
-                    )
+            GenericForeignKeyQuerySet(
+                OddNode.objects.all().select_related(),
+                gfk='bad_field_name'
+            )
 
     def test_works_with_duplicate_nodes(self):
         well = generate_random_well()
@@ -163,7 +165,8 @@ class GenericForeignKeyQuerySetTestCase(TestCase):
 
         queryset = well.items
         with self.assertRaises(FilterException):
-            self.assertEqual(3, len(queryset.filter(title__in=['foo','bar'])))
+            self.assertEqual(3, len(queryset.filter(title__in=['foo', 'bar'])))
+
 
 class MergeQuerySetTestCase(TestCase):
     def setUp(self):

--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -26,13 +26,6 @@ class SimpleWellViewTest(TestCase):
             "well_title": self.well.title,
         }
 
-    def assertInContext(self, var_name, other, template_or_context):
-        # TODO: support passing in a straight "context" (i.e., dict)
-        context = template_or_context.context_data
-        self.assertTrue(var_name in context,
-                msg="`%s` not in provided context" % var_name)
-        self.assertEqual(context[var_name], other)
-
     def test_raises_exception_without_template_name_param(self):
         kwargs = self.default_kwargs()
         del kwargs["template_name"]

--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -15,20 +15,26 @@ from ..views import SimpleWellView
 from ..views import QuerySetBackedWellView
 
 
-class WellViewTestCase(TestCase):
-    def setUp(self):
-        super(WellViewTestCase, self).setUp()
-        self.well = generate_random_well()
-
-
-class SimpleWellViewTest(WellViewTestCase):
+class SimpleWellViewTest(TestCase):
     view_class = SimpleWellView
+
+    def setUp(self):
+        super(SimpleWellViewTest, self).setUp()
+        self.factory = RequestFactory()
+        self.well = generate_random_well()
 
     def default_kwargs(self):
         return {
             "template_name": "index.html",
             "well_title": self.well.title,
         }
+
+    def assertInContext(self, var_name, other, template_or_context):
+        # TODO: support passing in a straight "context" (i.e., dict)
+        context = template_or_context.context_data
+        self.assertTrue(var_name in context,
+                msg="`%s` not in provided context" % var_name)
+        self.assertEqual(context[var_name], other)
 
     def test_raises_exception_without_template_name_param(self):
         kwargs = self.default_kwargs()

--- a/armstrong/core/arm_wells/tests/views.py
+++ b/armstrong/core/arm_wells/tests/views.py
@@ -1,18 +1,15 @@
-from django.core.exceptions import ImproperlyConfigured
-from django.db.models.query import QuerySet
-from django.http import HttpRequest
-from django.test.client import RequestFactory
-import fudge
 import random
 
-from .arm_wells_support.models import Story
-from ._utils import add_n_random_stories_to_well
-from ._utils import generate_random_story
-from ._utils import generate_random_well
-from ._utils import TestCase
+from django.core.exceptions import ImproperlyConfigured
+from django.test.client import RequestFactory
 
-from ..views import SimpleWellView
-from ..views import QuerySetBackedWellView
+from .arm_wells_support.models import Story
+from ._utils import (TestCase,
+                     add_n_random_stories_to_well,
+                     generate_random_story,
+                     generate_random_well)
+
+from ..views import SimpleWellView, QuerySetBackedWellView
 
 
 class SimpleWellViewTest(TestCase):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 django>=1.3
-django-reversion==1.3.3
+django-reversion==1.4
 armstrong.hatband

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,0 @@
-django>=1.3
-django-reversion==1.4
-armstrong.hatband

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,1 @@
--r ./base.txt
 armstrong.dev>=1.11.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,2 @@
 -r ./base.txt
-armstrong.dev>=1.4
+armstrong.dev>=1.11.0


### PR DESCRIPTION
This is a better, cleaner version of this attempted PR #18.

It removes unused imports. It orders them in what I think is a cleaner way (you can tell me to stop this if you just think it's horrible). I found some new things too.
- `TestCase` now uses `ArmstrongTestCase` instead of `DjangoTestCase`
- `TestCase` did setUp() that was only used in `SimpleWellViewTest` so I moved those tasks over
- I removed an unnecessary parent test case
- I found an orphan sanity check

It's meant as an extension to PR #20. So the actual diff is simpler. Here's the [diff](https://github.com/joncotton/armstrong.core.arm_wells/compare/additional_tests...tidy_tests) between those two.
