### PR TITLE
fix comparator was using strings, not numbers to determine order

### DIFF
--- a/armstrong/core/arm_wells/static/arm_wells/js/well-node-inline.js
+++ b/armstrong/core/arm_wells/static/arm_wells/js/well-node-inline.js
@@ -5,7 +5,7 @@ Node = Item.extend({
 NodeList = ItemList.extend({
     model: Node,
     comparator: function(node) {
-        return +node.get("order");
+        return parseInt(node.get("order"), 10);
     }
 });
 

--- a/armstrong/core/arm_wells/static/arm_wells/js/well-node-inline.js
+++ b/armstrong/core/arm_wells/static/arm_wells/js/well-node-inline.js
@@ -5,7 +5,7 @@ Node = Item.extend({
 NodeList = ItemList.extend({
     model: Node,
     comparator: function(node) {
-        return node.get("order");
+        return +node.get("order");
     }
 });
 


### PR DESCRIPTION
The old comparator was using the string values of the order attribute
instead of the numeric value, so you would get orders like:
0, 1, 10, 11, 2, 3, 4, 5, 6, 7, 8, 9

instead of
0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
