### PR TITLE
remove try except block by piggybacking off django's .latest()

### DIFF
--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -5,11 +5,6 @@ from django.db import models
 class WellManager(models.Manager):
     def get_current(self, title):
         now = datetime.datetime.now()
-        queryset = self.filter(type__title=title, pub_date__lte=now,
+        return self.filter(type__title=title, pub_date__lte=now,
                 active=True).exclude(expires__lte=now,
-                        expires__isnull=False).order_by('-pub_date')
-
-        try:
-            return queryset[0]
-        except IndexError:
-            raise self.model.DoesNotExist
+                        expires__isnull=False).latest('pub_date')


### PR DESCRIPTION
Pretty simple, change. If you're just trying to get the first of a queryset based on an order, using .latest() gives you the DoesNotExcept exception automagically.

Do or do not merge this, there is no try.
