### PR TITLE
Add Django 1.5 Compatibility to arm_wells

### DIFF
--- a/.travis_setup
+++ b/.travis_setup
@@ -1,4 +1,4 @@
 #!/bin/bash
-pip install -i http://armstrong.github.com/pypi.armstrongcms.org/index/ -r requirements/dev.txt
+pip install -i http://armstrong.github.com/pypi.armstrongcms.org/index/ --use-mirrors -r requirements/dev.txt
 pip install .
 pip install Django==$DJANGO_VERSION

--- a/README.rst
+++ b/README.rst
@@ -128,8 +128,15 @@ can add this however you like.  This works as a copy-and-paste solution:
 Once installed, you have to run either ``syncdb`` or ``migrate`` if you are
 using `South`_.
 
+.. note:: ``armstrong.core.arm_wells`` requires the package `django-reversion`_
+          which does not support multiple versions of Django.  Because of this,
+          we can't specify a version of django-reversion for you to use.  Please
+          consult the `wiki page`_ to determine which version you should use.
+
 .. _pip: http://www.pip-installer.org/
 .. _South: http://south.aeracode.org/
+.. _django-reversion: https://github.com/etianen/django-reversion/
+.. _wiki page: https://github.com/etianen/django-reversion/wiki/Compatible-Django-Versions
 
 
 Contributing

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.10alpha.0",
     "description": "Provides the basic well objects",
     "install_requires": [
-        "django-reversion==1.4.0",
+        "django-reversion",
         "armstrong.hatband>=1.2.4"
     ]
 }


### PR DESCRIPTION
`arm_wells` is currently broken in Django 1.5 because the `MultipleObjectMixin.get_context_data` expects `object_list` to be passed into its kwargs. This _did not_ change between Django 1.4 and 1.5. What _did_ change is that `TemplateView` (which is above `MultipleObjectMixin` in the MRO), returned a dict and didn't go further up the MRO (https://github.com/django/django/blob/stable/1.4.x/django/views/generic/base.py#L117-L120 vs https://github.com/django/django/blob/stable/1.5.x/django/views/generic/base.py#L153)
### TODO
- [x] get Django 1.4 to work again
- [x] add test:  `object_list` should be in the context of a `QuerySetBackedWellView` view because it extends `MultipleObjectMixin` (this is a bug in the current version of `arm_wells`)
- [x] extend test coverage to django 1.5
### Addendum

Django 1.4.3:

```
ipdb> QuerySetBackedWellView.__mro__
(<class 'armstrong.core.arm_wells.views.QuerySetBackedWellView'>, <class 'armstrong.core.arm_wells.views.SimpleWellView'>, <class 'django.views.generic.base.TemplateView'>, <class 'django.views.generic.base.TemplateResponseMixin'>, <class 'django.views.generic.base.View'>, <class 'django.views.generic.list.MultipleObjectMixin'>, <type 'object'>)
```

Django 1.5.1

```
ipdb> QuerySetBackedWellView.__mro__
(<class 'armstrong.core.arm_wells.views.QuerySetBackedWellView'>, <class 'armstrong.core.arm_wells.views.SimpleWellView'>, <class 'django.views.generic.base.TemplateView'>, <class 'django.views.generic.base.TemplateResponseMixin'>, <class 'django.views.generic.list.MultipleObjectMixin'>, <class 'django.views.generic.base.ContextMixin'>, <class 'django.views.generic.base.View'>, <type 'object'>)
```
